### PR TITLE
define cluster using yaml instead of python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 build
 .machines.yml
+venv
+.hypothesis

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -23,10 +23,10 @@ defaults:
             accept: 0.0.0.0/0
             protocol: tcp
     futuresystems:
-      <<inherit>>: defaults.cloud.openstack
+      <<inherit:defaults.cloud.openstack>>:
       image: Ubuntu-14.04-64
     chameleon:
-      <<inherit>>: defaults.cloud.openstack
+      <<inherit:defaults.cloud.openstack>>:
       image: CC-Ubuntu14.04
 
 
@@ -73,8 +73,11 @@ machines:
 
 
 host_vars:
-  <<index:services.zookeeper.machines:1>>: zookeeper_id
-  <<forall:machines>>:
+  <<index:services.zookeeper.machines:name:1>>:
+    zookeeper_id:
+  <<forall:machines:name>>:
     this_var_a: is the same for all machines
-  <<forall:machines.services.hadoop>>:
+  <<forall:services.hadoop.machines:name>>:
     this_var_b: is defined (and identical) only the "hadoop" nodes
+  <<forall:services.zookeeper.machines:name>>:
+    this_var_c: is defined only on zookeeper nodes

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -23,10 +23,10 @@ defaults:
             accept: 0.0.0.0/0
             protocol: tcp
     futuresystems:
-      inherit: defaults.cloud.openstack
+      <inherit>: defaults.cloud.openstack
       image: Ubuntu-14.04-64
     chameleon:
-      inherit: defaults.cloud.openstack
+      <inherit>: defaults.cloud.openstack
       image: CC-Ubuntu14.04
 
 

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -32,10 +32,7 @@ defaults:
       <<inherit:defaults.provider.openstack>>:
       image: CC-Ubuntu14.04
       create_floating_ip: true
-  cloud:
-    name: futuresystems
-    parameters:
-      <<inherit:defaults.provider.futuresystems>>:
+  cloud: # chameleon
 
 
 

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -75,7 +75,7 @@ machines:
 host_vars:
   services:
     zookeeper:
-      zookeeper_id: <<INDEX:services.zookeeper.machines:1>>
+      zookeeper_id: <<index:services.zookeeper.machines:1>>
   machines:
     controller:
       foo: 

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -73,9 +73,8 @@ machines:
 
 
 host_vars:
-  services:
-    zookeeper:
-      zookeeper_id: <<index:services.zookeeper.machines:1>>
-  machines:
-    controller:
-      foo: 
+  <<index:services.zookeeper.machines:1>>: zookeeper_id
+  <<forall:machines>>:
+    this_var_a: is the same for all machines
+  <<forall:machines.services.hadoop>>:
+    this_var_b: is defined (and identical) only the "hadoop" nodes

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -52,7 +52,7 @@ services:
 machines:
   controller:
     count: 3
-    for:
+    services:
       zookeeper:
       namenode:
         assign: 2
@@ -68,7 +68,7 @@ machines:
       hadoop:
   datanode:
     count: 10
-    for:
+    services:
       datanode:
 
 

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -69,9 +69,6 @@ machines:
       resourcemanager: 
         assign: 2
       datanode:
-        providers:
-          chameleon:
-            image: m1.xlarge
       frontend: 
         assign: 1
       hadoop:
@@ -79,6 +76,9 @@ machines:
     count: 10
     services:
       datanode:
+    providers:
+      chameleon:
+        image: m1.xlarge
 
 
 host_vars:

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -4,8 +4,9 @@ defaults:
   auth:
     public_key: ~/.ssh/id_rsa.pub
     private_key: ~/.ssh/id_rsa
-  cloud:
+  provider:
     openstack:
+      prefix: <<env:USER>>-
       flavor: m1.small
       key_name: <<env:HOSTNAME>>
       network: <<env:OS_PROJECT_NAME>>-net
@@ -22,20 +23,27 @@ defaults:
           - port: 80,443,8080
             accept: 0.0.0.0/0
             protocol: tcp
+      poll_until_active_seconds: 1
+      timeout_until_active_seconds: 360
     futuresystems:
-      <<inherit:defaults.cloud.openstack>>:
+      <<inherit:defaults.provider.openstack>>:
       image: Ubuntu-14.04-64
     chameleon:
-      <<inherit:defaults.cloud.openstack>>:
+      <<inherit:defaults.provider.openstack>>:
       image: CC-Ubuntu14.04
       create_floating_ip: true
+  cloud:
+    name: futuresystems
+    parameters:
+      <<inherit:defaults.provider.futuresystems>>:
+
 
 
 services:
   zookeeper:
   namenode:
     - hadoop
-  journalenode:
+  journalnode:
     - hadoop
   historyserver:
     - hadoop
@@ -57,13 +65,16 @@ machines:
       zookeeper:
       namenode:
         assign: 2
-      journalenode:
+      journalnode:
         assign: 1
       historyserver: 
         assign: 1
       resourcemanager: 
         assign: 2
       datanode:
+        providers:
+          chameleon:
+            image: m1.xlarge
       frontend: 
         assign: 1
       hadoop:

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -1,0 +1,81 @@
+
+
+defaults:
+  auth:
+    public_key: ~/.ssh/id_rsa.pub
+    private_key: ~/.ssh/id_rsa
+  cloud:
+    openstack:
+      flavor: m1.small
+      key_name: <<env:HOSTNAME>>
+      network: <<env:OS_PROJECT_NAME>>-net
+      create_floating_ip: false
+      floating_ip_pool: ext-net
+      security_groups: ["default"]
+      available_security_groups:
+        default:
+          - port: 22
+            accept: 0.0.0.0/0
+            protocol: tcp
+          - protocol: icmp
+        web:
+          - port: 80,443,8080
+            accept: 0.0.0.0/0
+            protocol: tcp
+    futuresystems:
+      inherit: defaults.cloud.openstack
+      image: Ubuntu-14.04-64
+    chameleon:
+      inherit: defaults.cloud.openstack
+      image: CC-Ubuntu14.04
+
+
+services:
+  zookeeper:
+  namenode:
+    - hadoop
+  journalenode:
+    - hadoop
+  historyserver:
+    - hadoop
+  resourcemanager:
+    - hadoop
+  datanode:
+    - hadoop
+  hadoop:
+  frontend:
+  gluster:
+  loadbalancer:
+
+
+
+machines:
+  controller:
+    count: 3
+    for:
+      zookeeper:
+      namenode:
+        assign: 2
+      journalenode:
+        assign: 1
+      historyserver: 
+        assign: 1
+      resourcemanager: 
+        assign: 2
+      datanode:
+      frontend: 
+        assign: 1
+      hadoop:
+  datanode:
+    count: 10
+    for:
+      datanode:
+
+
+host_vars:
+  services:
+    zookeeper:
+      zookeeper_id: <<INDEX:services.zookeeper.machines:1>>
+  machines:
+    controller:
+      foo: 

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -73,7 +73,7 @@ machines:
         assign: 1
       hadoop:
   datanode:
-    count: 10
+    count: 2
     services:
       datanode:
     providers:

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -23,10 +23,10 @@ defaults:
             accept: 0.0.0.0/0
             protocol: tcp
     futuresystems:
-      <inherit>: defaults.cloud.openstack
+      <<inherit>>: defaults.cloud.openstack
       image: Ubuntu-14.04-64
     chameleon:
-      <inherit>: defaults.cloud.openstack
+      <<inherit>>: defaults.cloud.openstack
       image: CC-Ubuntu14.04
 
 

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -28,6 +28,7 @@ defaults:
     chameleon:
       <<inherit:defaults.cloud.openstack>>:
       image: CC-Ubuntu14.04
+      create_floating_ip: true
 
 
 services:

--- a/requirements-unbounded.txt
+++ b/requirements-unbounded.txt
@@ -4,3 +4,5 @@ pyyaml
 traits
 easydict
 -e git://github.com/badi/pxul@v2.0.0#egg=pxul
+pyparsing
+hypothesis

--- a/requirements-unbounded.txt
+++ b/requirements-unbounded.txt
@@ -6,3 +6,4 @@ easydict
 -e git://github.com/badi/pxul@v2.0.0#egg=pxul
 pyparsing
 hypothesis
+python_log_indenter

--- a/vcl/__main__.py
+++ b/vcl/__main__.py
@@ -1,4 +1,7 @@
 
+import logger as logging
+logger = logging.getLogger(__name__)
+
 import sys
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import collections
@@ -16,6 +19,8 @@ def main():
 
 
     parser = ArgumentParser() #formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-v', '--verbose', action='count',
+                        help='Verbosity level, repeat for increased verbosity')
 
     subparsers = parser.add_subparsers(title='subcommands')
 
@@ -31,7 +36,21 @@ def main():
 
 
     opts = parser.parse_args()
+    set_verbosity_level(opts)
     opts.func(opts)
+
+
+def set_verbosity_level(opts):
+    if not opts.verbose:
+        logging.basicConfig(level=logging.CRITICAL)
+    elif opts.verbose == 1:
+        logging.basicConfig(level=logging.WARNING)
+    elif opts.verbose == 2:
+        logging.basicConfig(level=logging.INFO)
+    elif opts.verbose >= 3:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        raise ValueError('Verbosity cannot be < 0: %s' % opts.verbose)
 
 
 if __name__ == '__main__':

--- a/vcl/camel/__init__.py
+++ b/vcl/camel/__init__.py
@@ -1,0 +1,3 @@
+from parser import Parser
+from parser import env_handler
+from visitor import Visitor

--- a/vcl/camel/parser.py
+++ b/vcl/camel/parser.py
@@ -1,13 +1,10 @@
 
-import logger as logging
+import vcl.logger as logging
 logger = logging.getLogger(__name__)
 
 
-from pyparsing import CaselessLiteral, Literal, Optional, Word,\
-    pyparsing_common
-import pyparsing
-from string import ascii_letters,  digits, letters, punctuation
-import copy
+from pyparsing import CaselessLiteral, Literal, Optional, Word
+from string import  digits, letters, punctuation
 import os
 
 

--- a/vcl/camel/visitor.py
+++ b/vcl/camel/visitor.py
@@ -1,0 +1,155 @@
+import vcl.logger as logging
+logger = logging.getLogger(__name__)
+
+from parser import Parser
+
+import copy
+import operator
+
+import traits.api as T
+from traits.api import HasTraits
+
+
+
+class Visitor(HasTraits):
+
+    handlers = T.List()
+    context  = T.Any()
+
+
+    def _getSymbolBy(self, getter, instance, symbol):
+        names = symbol.split('.')
+        i = instance
+        for name in names:
+            if not name: break
+            i = getter(i, name)
+        return i
+
+    def _getObjectSymbol(self, obj, symbol):
+        return self._getSymbolBy(getattr, obj, symbol)
+
+
+    def _getDictSymbol(self, dictionary, symbol):
+        return self._getSymbolBy(operator.getitem, dictionary, symbol)
+
+
+    def _getSymbol(self, value, symbol):
+        if isinstance(value, dict):
+            return self._getDictSymbol(value, symbol)
+        else:
+            return self._getObjectSymbol(value, symbol)
+
+
+    def transform(self, spec):
+        self.spec = copy.deepcopy(spec)
+        return self.visit(self.spec)
+
+
+    def visit_generic(self, node):
+        return node
+
+
+    def visit(self, node):
+        typ  = type(node).__name__
+        attr = 'visit_{}'.format(typ)
+        visitor = getattr(self, attr, self.visit_generic)
+        logger.debug('Visiting type={} method={}'.format(typ, visitor.func_name))
+        logger.debug('Value="{}"'.format(repr(node)))
+        return visitor(node)
+
+
+    def transform_dict(self, node, key):
+
+
+        logger.debug('Transforming dict key: {}'.format(key))
+
+        ### don't use pyparsing's addParseAction as this causes
+        ### bizarre errors (likely due to some pyparsing
+        ### statefullness)
+
+
+        p = Parser()
+        parsed = p.keyword.parseString(key)
+        logger.debug('Parsed items: {}'.format(parsed.items()))
+        
+        if parsed.directive == 'inherit':
+            # This replaces the <<inherits:...>> keyword with the target.
+
+            spec = self._getDictSymbol(self.spec, parsed.symbol)
+            spec = copy.copy(spec)
+            del node[key]
+            for k, v in node.iteritems():
+                spec[k] = v
+
+            for k, v in spec.iteritems():
+                node[k] = v
+
+
+        elif parsed.directive == 'index':
+            seq = self._getObjectSymbol(self.context, parsed.symbol)
+
+            for variable in node[key].keys():
+                for i, val in enumerate(seq, parsed.index):
+                    k = self._getSymbol(val, parsed.attribute)
+                    if k not in node:
+                        node[k] = dict()
+                    node[k][variable] = i
+            del node[key]
+
+
+        elif parsed.directive == 'forall':
+            seq = self._getObjectSymbol(self.context, parsed.symbol)
+
+            for variable, value in node[key].iteritems():
+                for val in seq:
+                    k = self._getSymbol(val, parsed.attribute)
+                    if k not in node:
+                        node[k] = dict()
+                    node[k][variable] = value
+            del node[key]
+
+        else:
+            logger.error('Unable to handle directive "{}"'.format(parsed.directive))
+            raise ValueError("I don't know how to handle directive {}"
+                             .format(parsed.directive))
+
+
+    def visit_dict(self, node):
+
+        seen = set()
+
+        logger.debug('Visiting dict keys')
+        while True:
+            keys = set(node.keys())
+
+            try:
+                k = keys.difference(seen).pop()
+            except KeyError:
+                break
+
+            logger.debug('Processing key "{}"'.format(k))
+            if k.startswith('<<') and k.endswith('>>'):
+                self.transform_dict(node, k)
+            seen.add(k)
+
+
+        logger.debug('Visiting dict values')
+        for k in node:
+            logger.add()
+            node[k] = self.visit(node[k])
+            logger.sub()
+
+        return node
+
+
+    def visit_list(self, node):
+        for i in xrange(len(node)):
+            logger.add()
+            node[i] = self.visit(node[i])
+            logger.sub()
+        return node
+
+
+    def visit_str(self, node):
+        return Parser.transform('expansion', self.handlers, node)
+

--- a/vcl/logger.py
+++ b/vcl/logger.py
@@ -8,6 +8,9 @@ def getLogger(name):
 
 basicConfig = logging.basicConfig
 
+logging.getLogger('requests').setLevel(logging.WARNING)
+logging.getLogger('urllib3').setLevel(logging.WARNING)
+
 
 CRITICAL = logging.CRITICAL
 ERROR = logging.ERROR

--- a/vcl/logger.py
+++ b/vcl/logger.py
@@ -1,0 +1,17 @@
+
+import logging
+from python_log_indenter import IndentedLoggerAdapter as Logger
+
+
+def getLogger(name):
+    return Logger(logging.getLogger(name))
+
+basicConfig = logging.basicConfig
+
+
+CRITICAL = logging.CRITICAL
+ERROR = logging.ERROR
+WARNING = logging.WARNING
+INFO = logging.INFO
+DEBUG = logging.DEBUG
+NOTSET = logging.NOTSET

--- a/vcl/openstack.py
+++ b/vcl/openstack.py
@@ -71,16 +71,16 @@ def wait_until(expr, sleep_time=1, max_time=60):
     import time
     slept = 0
     while not expr():
-        msg = '{} / {}'.format(slept+sleep_time, max_time)
-        sys.stdout.write(msg)
-        sys.stdout.flush()
-        sys.stdout.write('\b' * len(msg))
+        msg = '{} / {} seconds'.format(slept+sleep_time, max_time)
+        sys.stderr.write(msg)
+        sys.stderr.flush()
+        sys.stderr.write('\b' * len(msg))
         time.sleep(sleep_time)
         slept += sleep_time
         if slept >= max_time:
-            print(msg + ' Timed out')
+            logger.critical(msg + ' Timed out')
             raise RuntimeError, 'Timeout while waiting for {}'.format(expr)
-    print(msg + '...done')
+    logger.info(msg + '...done')
 
 
 

--- a/vcl/openstack.py
+++ b/vcl/openstack.py
@@ -89,9 +89,11 @@ def boot(cluster, dry_run=False, **kws):
     nova = get_client()
     state = State(storage='.machines')
 
+    logger.mem_save('boot')
+
     for node in cluster.machines:
         node_name = cluster.cloud.prefix + node.name
-        logger.info('Booting %s as %s on', node.name, node_name, node.cloud.name)
+        logger.mem('boot').info('Booting %s as %s on %s', node.name, node_name, node.cloud.name).add()
 
         image_name = node.cloud.image
         flavor_name = node.cloud.flavor
@@ -123,9 +125,9 @@ def boot(cluster, dry_run=False, **kws):
         ################################################## boot
 
         try:
-            logger.info('Checking if already booted').add()
+            logger.info('Checking if already booted')
             nova.servers.find(name=node_name)
-            logger.info('...true').sub()
+            logger.info('...true')
             continue
         except novaclient.exceptions.NotFound:
 

--- a/vcl/openstack.py
+++ b/vcl/openstack.py
@@ -102,7 +102,6 @@ def boot(cluster, dry_run=False, **kws):
         sec_groups = node.cloud.security_groups
 
         if dry_run:
-            yield node
             continue
 
         ################################################## upload key if needed
@@ -203,4 +202,3 @@ def boot(cluster, dry_run=False, **kws):
 
         ################################################## save
         state.set_machine(node)
-        yield node

--- a/vcl/openstack.py
+++ b/vcl/openstack.py
@@ -202,3 +202,6 @@ def boot(cluster, dry_run=False, **kws):
 
         ################################################## save
         state.set_machine(node)
+
+
+    logger.mem_clear('boot')

--- a/vcl/openstack.py
+++ b/vcl/openstack.py
@@ -194,14 +194,14 @@ def boot(cluster, dry_run=False, **kws):
 
         ################################################## extra discs
 
-        for disk in node.extra_disks:
-            # cinder not support yet
-            print 'WARNING extra disks not supported yet'
-            # node.unset_dynamic('extra_disks')
+        # for disk in node.extra_disks:
+        #     # cinder not support yet
+        #     print 'WARNING extra disks not supported yet'
+        #     # node.unset_dynamic('extra_disks')
 
 
-        ################################################## save
-        state.set_machine(node)
+        # ################################################## save
+        # state.set_machine(node)
 
 
     logger.mem_clear('boot')

--- a/vcl/openstack.py
+++ b/vcl/openstack.py
@@ -164,16 +164,16 @@ def boot(cluster, dry_run=False, **kws):
             try:
                 # first try to get a free ip
                 floating_ip = nova.floating_ips.findall(instance_id=None)[0]
-                logger.info('...using %s', floating_ip)
+                logger.info('...using %s', floating_ip.ip)
             except IndexError:
                 pool = node.cloud.floating_ip_pool
                 floating_ip = nova.floating_ips.create(pool=pool)
-                logger.info('...allocated %s from pool %s', floating_ip, pool)
+                logger.info('...allocated %s from pool %s', floating_ip.ip, pool)
 
             logger.info('...associating')
             vm.add_floating_ip(floating_ip)
 
-            node.address.external = floating_ip
+            node.address.external = floating_ip.ip
             logger.info('...done')
 
 

--- a/vcl/parser.py
+++ b/vcl/parser.py
@@ -153,7 +153,7 @@ def test_env(val):
 
 
 @composite
-def variable_name(draw):
+def symbols(draw):
     start_alpha, rest_alpha = symbol_alphabet
 
     start = draw(text(start_alpha, min_size=1))
@@ -165,8 +165,7 @@ def variable_name(draw):
 def index_strategy(draw):
     directive = draw(sampled_from('index Index INdex INDex INDEx INDEX'.split()))
 
-    symbols = draw(lists(variable_name(), min_size=1))
-    symbol = '.'.join(symbols)
+    symbol = '.'.join(draw(lists(symbols(), min_size=1)))
 
     index = draw(integers(min_value=0))
     r = '{}:{}:{}'.format(directive, symbol, index)

--- a/vcl/parser.py
+++ b/vcl/parser.py
@@ -1,10 +1,15 @@
 
+import logger as logging
+logger = logging.getLogger(__name__)
+
+
 from pyparsing import CaselessLiteral, Literal, Optional, Word,\
     pyparsing_common
 import pyparsing
 from string import ascii_letters,  digits, letters, punctuation
 import copy
 import os
+
 
 
 ################################################################################
@@ -123,9 +128,10 @@ keyword = p.keyword
 
 def env_handler(tokens):
     val = os.getenv(tokens.env)
-    print 'Expanding', tokens.env, '=>', val
     if val is None:
-        print 'WARNING: no value for', tokens.env, ', skipping'
+        logger.warning('no value for {}, skipping'.format(tokens.env))
+    else:
+        logger.info('Expanding {} => {}'.format(tokens.env, val))
     return val
 
 

--- a/vcl/parser.py
+++ b/vcl/parser.py
@@ -122,8 +122,12 @@ keyword = p.keyword
 ################################################################################
 
 def env_handler(tokens):
-    print 'Expanding', tokens.env
-    return os.getenv(tokens.env)
+    val = os.getenv(tokens.env)
+    print 'Expanding', tokens.env, '=>', val
+    if val is None:
+        print 'WARNING: no value for', tokens.env, ', skipping'
+    return val
+
 
 
 ################################################################################

--- a/vcl/parser.py
+++ b/vcl/parser.py
@@ -70,6 +70,12 @@ index = index_directive + delim + symbol + delim + index_value
 expansion = start + (env ^ index) + end
 
 ################################################################################
+
+inherit = Directive('inherit') + delim + symbol
+forall = Directive('forall') + delim + symbol
+
+keyword = start + (inherit ^ index ^ forall) + end
+
 ## handlers
 ################################################################################
 
@@ -163,6 +169,28 @@ def expansions(draw):
     return '<<{}>>'.format(x), es
 
 
+@composite
+def inherits(draw):
+    directive = draw(sampled_from('inherit inHERit INHERIT'.split()))
+    symbol = draw(symbols())
+    s = '{}:{}'.format(directive, symbol)
+    return s, expected(directive=directive.lower(), symbol=symbol)
+
+
+@composite
+def foralls(draw):
+    directive = draw(sampled_from('forall foRAll FORALL'.split()))
+    symbol = draw(symbols())
+    s = '{}:{}'.format(directive, symbol)
+    return s, expected(directive=directive.lower(), symbol=symbol)
+
+
+@composite
+def keywords(draw):
+    k, expected = draw(one_of(inherits(), foralls()))
+    return '<<{}>>'.format(k), expected
+
+
 ################################################## tests
 
 @given(one_of(just(':'), just('<<'), just('>>')))
@@ -208,6 +236,32 @@ def test_expansion(val):
         assertEQ(r.index, expected.index)
     else:
         raise ValueError('Unknown directive {}'.format(r['directive']))
+
+
+@given(inherits())
+def test_inherit(val):
+    s, expected = val
+    r = inherit.parseString(s)
+    assert 'directive' in r.keys()
+    assert 'symbol' in r.keys()
+    assertEQ(r.directive, expected.directive)
+    assertEQ(r.symbol, expected.symbol)
+
+
+@given(foralls())
+def test_forall(val):
+    s, expected = val
+    r = forall.parseString(s)
+    assert 'directive' in r.keys()
+    assert 'symbol' in r.keys()
+    assertEQ(r.directive, expected.directive)
+    assertEQ(r.symbol, expected.symbol)
+
+
+@given(keywords())
+def test_keywords(val):
+    s, expected = val
+    assert keyword.parseString(s)
 
 
 @composite

--- a/vcl/parser.py
+++ b/vcl/parser.py
@@ -27,8 +27,9 @@ start = Literal('<<')
 end = Literal('>>')
 delim = Literal(':')
 
-symbol = Word(letters, letters + digits + '_.')\
-         .setResultsName('symbol')
+symbol_alphabet = (letters, letters + digits + '_.')
+
+symbol = Word(*symbol_alphabet).setResultsName('symbol')
 
 env_var_name = Word(env_var_name_alphabet_init,
                     env_var_name_alphabet_rest)\
@@ -153,8 +154,10 @@ def test_env(val):
 
 @composite
 def variable_name(draw):
-    start = draw(text(letters+'_', min_size=1))
-    rest = draw(text(letters+digits+'_'))
+    start_alpha, rest_alpha = symbol_alphabet
+
+    start = draw(text(start_alpha, min_size=1))
+    rest  = draw(text(rest_alpha))
     return start + rest
 
 

--- a/vcl/parser.py
+++ b/vcl/parser.py
@@ -77,37 +77,6 @@ forall = Directive('forall') + delim + symbol \
 
 keyword = start + (inherit ^ index ^ forall) + end
 
-################################################################################
-## handlers
-################################################################################
-
-def env_handler(token):
-    import os
-    var = token.env
-    return os.getenv(var)
-
-
-def index_handler(scope, token):
-    print 'hello'
-    return 'FOOBAR'
-    # namespace = token.symbol.split('.')
-    # obj = scope
-    # for attr in namespace:
-    #     obj = getattr(obj, attr)
-
-    # assert isinstance(obj, Sequence)
-    # for i, x in enumerate(obj, token.index):
-    #     yield i
-
-
-
-def transform(parser, actions, string):
-    if '<<env:OS_PROJECT_NAME>>-net' in string:
-        import pdb; pdb.set_trace()
-    
-    parser_copy = copy.copy(parser)
-    parser_copy.addParseAction(*actions)
-    return parser_copy.transformString(string)
 
 
 ################################################################################

--- a/vcl/parser.py
+++ b/vcl/parser.py
@@ -1,0 +1,162 @@
+
+from pyparsing import CaselessLiteral, Literal, Optional, Word
+from string import digits, letters, punctuation
+
+
+"""
+Expansions are defined as follows:
+
+expansion := start (env | count) end
+start := "<<"
+delim := ">>"
+env := "env" delim env_var_name [delim env_var_value]
+env_var_name := alphanumeric | "-" | "_" | "+"
+index := "index" delim integer
+"""
+
+env_var_name_alphabet_init = letters
+env_var_name_alphabet_rest = letters + '_'
+env_var_vals_alphabet = digits + letters + punctuation + ' \t'
+
+
+start = Literal('<<')
+end = Literal('>>')
+delim = Literal(':')
+
+
+env_var_name = Word(env_var_name_alphabet_init,
+                    env_var_name_alphabet_rest)\
+                    .setResultsName('env')
+
+env_directive = CaselessLiteral('env')\
+                .setResultsName('directive')\
+                .setParseAction(lambda toks: toks['directive'].lower())
+env = env_directive + delim + env_var_name
+
+index_directive = CaselessLiteral('index')\
+                  .setResultsName('directive')\
+                  .setParseAction(lambda toks: toks['directive'].lower())
+
+index_value = Word(digits)\
+        .setResultsName('index')\
+        .setParseAction(lambda s, loc, toks: int(toks['index']))
+              
+index = index_directive + delim + index_value
+expansion = start + (env ^ index) + end
+
+################################################################################
+## tests
+################################################################################
+
+from hypothesis import given, example, assume
+from hypothesis.strategies import text, composite, one_of, sampled_from, integers
+from pyparsing import ParseException
+
+
+class LiteralParserTesters(object):
+
+    def _test(self, literal, parser, example):
+        if example.startswith(literal):
+            assert parser.parseString(example)
+        else: # should throw exception
+            try:
+                parser.parseString(example)
+            except Exception as e:
+                assert isinstance(e, ParseException), e
+            else:
+                raise ValueError(example)
+
+    def run(self):
+        self.test_start()
+        self.test_end()
+        self.test_delim()
+
+
+    @given(text())
+    @example('<<')
+    def test_start(self, s):
+        assume(len(s.strip()) > 0)
+        self._test('<<', start, s)
+
+
+    @given(text())
+    @example('>>')
+    def test_end(self, s):
+        assume(len(s.strip()) > 0)
+        self._test('>>', end, s)
+
+
+    @given(text())
+    @example(':')
+    def test_delim(self, s):
+        assume(len(s.strip()) > 0)
+        self._test(':', delim, s)
+
+
+@composite
+def env_strategy(draw):
+    directive = draw(sampled_from('env ENV eNv EnV eNV ENv'.split()))
+    name_start = draw(text(env_var_name_alphabet_init, min_size=1))
+    name_rest  = draw(text(env_var_name_alphabet_rest))
+    name = name_start + name_rest
+
+    result = '{}:{}'.format(directive, name)
+    return result, name
+
+
+@given(env_strategy())
+def test_env(val):
+    s, expected = val
+    r = env.parseString(s)
+    assert 'env' in r.keys()
+    assert r['env'] == expected, (r['env'], expected)
+
+
+@composite
+def index_strategy(draw):
+    directive = draw(sampled_from('index Index INdex INDex INDEx INDEX'.split()))
+    index = draw(integers(min_value=0))
+    r = '{}:{}'.format(directive, index)
+    return r, index
+
+
+@given(index_strategy())
+def test_index(val):
+    s, expected = val
+    r = index.parseString(s)
+    assert 'index' in r.keys()
+    assert r['index'] == expected, (r['index'], expected)
+
+
+@composite
+def expansion_strategy(draw, elements=one_of(env_strategy(), index_strategy())):
+    x, expected = draw(elements)
+    return '<<{}>>'.format(x), expected
+    
+
+@given(expansion_strategy())
+def test_expansion(val):
+    s, expected = val
+    r = expansion.parseString(s)
+    assert 'directive' in r.keys()
+    if r['directive'] == 'env':
+        assert 'env' in r.keys()
+        assert r['env'] == expected
+    elif r['directive'] == 'index':
+        assert 'index' in r.keys()
+        assert r['index'] == expected
+    else:
+        raise ValueError('Unknown directive {}'.format(r['directive']))
+
+
+        
+
+def run_tests():
+    LiteralParserTesters().run()
+    test_env()
+    test_index()
+    test_expansion()
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/vcl/scripts/boot.py
+++ b/vcl/scripts/boot.py
@@ -4,7 +4,7 @@ Boot virtual machines
 
 from __future__ import absolute_import
 
-from vcl.specification import update_spec, mk_nodes, load_spec, inventory_format
+from vcl.spec2 import Cluster
 from vcl import openstack
 import yaml
 # from vcl.boot import libvirt
@@ -23,8 +23,10 @@ def add_parser(p):
         , inventory_filename \
         , machines_filename
 
-    p.add_argument('--provider', '-p', metavar='STR', default=None,
+    p.add_argument('--provider', '-p', metavar='STR', default='openstack',
                    help='The VM provider')
+    p.add_argument('--cloud', '-c', metavar='STR', default=None,
+                   help='The name of the cloud in the specification')
     p.add_argument('--specfile', '-s', metavar='FILE',
                    default=spec_filename, help='The cluster specification file')
     p.add_argument('--inventory', '-i', metavar='FILE',
@@ -34,28 +36,32 @@ def add_parser(p):
                    help='Don\'t actually do anything')
     p.add_argument('--machines', '-m', metavar='FILE', default=machines_filename,
                    help='The machine file to write')
-    p.add_argument('--prefix', '-P', metavar='STR', default='',
+    p.add_argument('--prefix', '-P', metavar='STR', default=Name, type=str,
                    help='Prefix the name (not hostname) with this string')
-    p.add_argument('--wait-until-active-timeout', '-a', default=360, type=int,
+    p.add_argument('--timeout-until-active-seconds', '-a', default=None, type=int,
                    help='Number of seconds to wait for a node to become ACTIVE before giving up')
-    p.add_argument('--wait-until-active-poll', '-A', default=1, type=int,
+    p.add_argument('--poll-until-active-seconds', '-A', default=None, type=int,
                    help='Number of seconds to wait between polling a new instance to see if it is ACTIVE')
 
 
 def main(opts):
     global __PROVIDERS
 
-    spec = load_spec(opts.specfile)
-    nodes = mk_nodes(spec, provider=opts.provider)
-    update_spec(spec, nodes)
+    cluster = Cluster.load_yaml(opts.specfile)
+    cluster.cloud.name = opts.cloud
+    cluster.cloud.parameters = opts.provider.parameters[opts.cloud]
 
-    provider = opts.provider or spec.defaults.provider
+    if opts.prefix:
+        cluster.cloud.parameters.prefix = opts.prefix
 
-    module = __PROVIDERS[provider]
-    machines = module.boot(nodes, prefix=opts.prefix, dry_run=opts.dry_run,
-                           waitForActiveSleep=opts.wait_until_active_poll,
-                           waitForActiveTimeout=opts.wait_until_active_timeout,
-                           )
+    if opts.poll_until_active_seconds:
+        cluster.cloud.parameters.poll_until_active_seconds = opts.poll_until_active_seconds
+
+    if opts.timeout_until_active_seconds:
+        cluster.cloud.parameters.timeout_until_active_seconds = opts.timeout_until_active_seconds
+
+
+    openstack.boot(cluster, dry_run=opts.dry_run)
 
     with open(opts.machines, 'w') as fd: fd.write('')
 

--- a/vcl/scripts/boot.py
+++ b/vcl/scripts/boot.py
@@ -46,8 +46,7 @@ def main(opts):
     global __PROVIDERS
 
     cluster = Cluster.load_yaml(opts.specfile)
-    cluster.cloud.name = opts.cloud
-    cluster.cloud.parameters = opts.provider.parameters[opts.cloud]
+    cluster.assign_to_cloud(opts.cloud)
 
     if opts.prefix:
         cluster.cloud.parameters.prefix = opts.prefix

--- a/vcl/scripts/boot.py
+++ b/vcl/scripts/boot.py
@@ -60,17 +60,17 @@ def main(opts):
 
     openstack.boot(cluster, dry_run=opts.dry_run)
 
-    with open(opts.machines, 'w') as fd: fd.write('')
+    # with open(opts.machines, 'w') as fd: fd.write('')
 
-    for m in machines:
-        with open(opts.machines, 'a') as fd:
-            o = {m.hostname: m.to_simple_types()}
-            s = yaml.dump(o, default_flow_style=False)
-            fd.write(s)
+    # for m in machines:
+    #     with open(opts.machines, 'a') as fd:
+    #         o = {m.hostname: m.to_simple_types()}
+    #         s = yaml.dump(o, default_flow_style=False)
+    #         fd.write(s)
 
-    with open(opts.inventory, 'w') as fd:
-        i = inventory_format(spec)
-        fd.write(i)
+    # with open(opts.inventory, 'w') as fd:
+    #     i = inventory_format(spec)
+    #     fd.write(i)
 
     # TODO: write_inventory(opts.inventory, mod.inventory, nodes)
 

--- a/vcl/scripts/boot.py
+++ b/vcl/scripts/boot.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import
 
 from vcl.spec2 import Cluster
 from vcl import openstack
-import yaml
-# from vcl.boot import libvirt
 
 
 __PROVIDERS = dict(

--- a/vcl/scripts/boot.py
+++ b/vcl/scripts/boot.py
@@ -34,7 +34,7 @@ def add_parser(p):
                    help='Don\'t actually do anything')
     p.add_argument('--machines', '-m', metavar='FILE', default=machines_filename,
                    help='The machine file to write')
-    p.add_argument('--prefix', '-P', metavar='STR', default=Name, type=str,
+    p.add_argument('--prefix', '-P', metavar='STR', default=None, type=str,
                    help='Prefix the name (not hostname) with this string')
     p.add_argument('--timeout-until-active-seconds', '-a', default=None, type=int,
                    help='Number of seconds to wait for a node to become ACTIVE before giving up')

--- a/vcl/scripts/defaults.py
+++ b/vcl/scripts/defaults.py
@@ -5,4 +5,4 @@ machines_filename = '.machines.yml'
 
 
 import logger
-loglevel = logger.info
+loglevel = logger.INFO

--- a/vcl/scripts/defaults.py
+++ b/vcl/scripts/defaults.py
@@ -1,4 +1,8 @@
 
-spec_filename = '.cluster.py'
+spec_filename = 'cluster.py'
 inventory_filename = 'inventory.txt'
 machines_filename = '.machines.yml'
+
+
+import logger
+loglevel = logger.info

--- a/vcl/scripts/defaults.py
+++ b/vcl/scripts/defaults.py
@@ -1,5 +1,5 @@
 
-spec_filename = 'cluster.py'
+spec_filename = 'cluster.yaml'
 inventory_filename = 'inventory.txt'
 machines_filename = '.machines.yml'
 

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -231,6 +231,14 @@ class ClusterLoader(object):
 
     @classmethod
     def phase1(cls, yaml_string):
+        """First pas through to load the cluster definition
+
+        :param yaml_string: YAML-formatted string
+        :returns: the cluster definition
+        :rtype: Cluster
+        """
+
+        logger.debug('Running Phase 1')
 
         d = yaml.safe_load(yaml_string)
         d = EasyDict(d)
@@ -254,6 +262,15 @@ class ClusterLoader(object):
     
     @classmethod
     def phase2(cls, yaml_string, cluster):
+        """Second pass through to expand any directives
+
+        :param yaml_string: the YAML-formatted string
+        :param cluster: context
+        :returns: the cluster
+        :rtype: Cluster
+        """
+
+        logger.debug('Running Phase 2')
 
         spec_dict = yaml.safe_load(yaml_string)
 

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -412,11 +412,11 @@ def _load_host_vars(root):
     return AnsibleVars(kind='host_vars', vars=root)
 
 
-def test(path):
+def _test(path):
     c = Cluster.load_yaml(open(path).read())
     return c
 
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    test('cluster.yaml')
+    _test('cluster.yaml')

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -7,9 +7,8 @@ logger = logging.getLogger(__name__)
 
 import random
 import copy
-from functools import partial
-import collections
 import operator
+
 
 import traits.api as T
 from traits.api import HasTraits, TraitHandler
@@ -227,6 +226,7 @@ class SpecificationVisitor(HasTraits):
 
     handlers = T.List()
     context  = T.Trait(Cluster)
+
 
     def _getSymbolBy(self, getter, instance, symbol):
         names = symbol.split('.')

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -1,14 +1,10 @@
 
-import parser
-from parser import Parser
 import logger as logging
-
 logger = logging.getLogger(__name__)
 
-import random
-import copy
-import operator
+import camel
 
+import random
 
 import traits.api as T
 from traits.api import HasTraits, TraitHandler
@@ -204,8 +200,8 @@ class ClusterLoader(object):
 
         spec_dict = yaml.safe_load(yaml_string)
 
-        visitor = SpecificationVisitor(
-            handlers = [parser.env_handler],
+        visitor = camel.Visitor(
+            handlers = [camel.env_handler],
             context  = cluster,
         )
         
@@ -221,148 +217,6 @@ class ClusterLoader(object):
         cluster = cls.phase2(yaml_string, cluster)
         return cluster
 
-
-class SpecificationVisitor(HasTraits):
-
-    handlers = T.List()
-    context  = T.Trait(Cluster)
-
-
-    def _getSymbolBy(self, getter, instance, symbol):
-        names = symbol.split('.')
-        i = instance
-        for name in names:
-            if not name: break
-            i = getter(i, name)
-        return i
-
-    def _getObjectSymbol(self, obj, symbol):
-        return self._getSymbolBy(getattr, obj, symbol)
-
-
-    def _getDictSymbol(self, dictionary, symbol):
-        return self._getSymbolBy(operator.getitem, dictionary, symbol)
-
-
-    def _getSymbol(self, value, symbol):
-        if isinstance(value, dict):
-            return self._getDictSymbol(value, symbol)
-        else:
-            return self._getObjectSymbol(value, symbol)
-
-
-    def transform(self, spec):
-        self.spec = copy.deepcopy(spec)
-        return self.visit(self.spec)
-
-
-    def visit_generic(self, node):
-        return node
-
-
-    def visit(self, node):
-        typ  = type(node).__name__
-        attr = 'visit_{}'.format(typ)
-        visitor = getattr(self, attr, self.visit_generic)
-        logger.debug('Visiting type={} method={}'.format(typ, visitor.func_name))
-        logger.debug('Value="{}"'.format(repr(node)))
-        return visitor(node)
-
-
-    def transform_dict(self, node, key):
-
-
-        logger.debug('Transforming dict key: {}'.format(key))
-
-        ### don't use pyparsing's addParseAction as this causes
-        ### bizarre errors (likely due to some pyparsing
-        ### statefullness)
-
-
-        p = Parser()
-        parsed = p.keyword.parseString(key)
-        logger.debug('Parsed items: {}'.format(parsed.items()))
-        
-        if parsed.directive == 'inherit':
-            # This replaces the <<inherits:...>> keyword with the target.
-
-            spec = self._getDictSymbol(self.spec, parsed.symbol)
-            spec = copy.copy(spec)
-            del node[key]
-            for k, v in node.iteritems():
-                spec[k] = v
-
-            for k, v in spec.iteritems():
-                node[k] = v
-
-
-        elif parsed.directive == 'index':
-            seq = self._getObjectSymbol(self.context, parsed.symbol)
-
-            for variable in node[key].keys():
-                for i, val in enumerate(seq, parsed.index):
-                    k = self._getSymbol(val, parsed.attribute)
-                    if k not in node:
-                        node[k] = dict()
-                    node[k][variable] = i
-            del node[key]
-
-
-        elif parsed.directive == 'forall':
-            seq = self._getObjectSymbol(self.context, parsed.symbol)
-
-            for variable, value in node[key].iteritems():
-                for val in seq:
-                    k = self._getSymbol(val, parsed.attribute)
-                    if k not in node:
-                        node[k] = dict()
-                    node[k][variable] = value
-            del node[key]
-
-        else:
-            logger.error('Unable to handle directive "{}"'.format(parsed.directive))
-            raise ValueError("I don't know how to handle directive {}"
-                             .format(parsed.directive))
-
-
-    def visit_dict(self, node):
-
-        seen = set()
-
-        logger.debug('Visiting dict keys')
-        while True:
-            keys = set(node.keys())
-
-            try:
-                k = keys.difference(seen).pop()
-            except KeyError:
-                break
-
-            logger.debug('Processing key "{}"'.format(k))
-            if k.startswith('<<') and k.endswith('>>'):
-                self.transform_dict(node, k)
-            seen.add(k)
-
-
-        logger.debug('Visiting dict values')
-        for k in node:
-            logger.add()
-            node[k] = self.visit(node[k])
-            logger.sub()
-
-        return node
-
-
-    def visit_list(self, node):
-        for i in xrange(len(node)):
-            logger.add()
-            node[i] = self.visit(node[i])
-            logger.sub()
-        return node
-
-
-    def visit_str(self, node):
-        return Parser.transform('expansion', self.handlers, node)
 
 
 ##################################################

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -514,6 +514,5 @@ def _test(path):
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     c = _test('cluster.yaml')
-    for v in c.vars:
-        v.materialize()
+    print c.get_inventory_ini()
     

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -376,6 +376,16 @@ def _load_machines(root, services, defaults):
     return machines
 
 
+def _load_cloud(root):
+    if root.cloud is None:
+        return None
+    else:
+        assert 'name' in root.cloud.keys(), root.cloud.keys()
+        assert 'parameters' in root.cloud.keys(), root.cloud.keys()
+        return Cloud(name=root.cloud.name,
+                     parameters=root.cloud.parameters)
+
+
 def _load_host_vars(root):
     return AnsibleVars(kind='host_vars', vars=root)
 

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -1,5 +1,6 @@
 
 import parser
+from parser import Parser
 
 import random
 import copy
@@ -170,8 +171,7 @@ class ClusterLoader(object):
         spec_dict = yaml.load(yaml_string)
 
         visitor = SpecificationVisitor(
-            handlers = [parser.env_handler,
-                        partial(parser.index_handler, cluster)],
+            handlers = [parser.env_handler],
             context  = cluster,
         )
         
@@ -239,7 +239,8 @@ class SpecificationVisitor(HasTraits):
         ### statefullness)
 
 
-        parsed = parser.keyword.parseString(key)
+        p = Parser()
+        parsed = p.keyword.parseString(key)
         
         if parsed.directive == 'inherit':
             # This replaces the <<inherits:...>> keyword with the target.
@@ -312,8 +313,8 @@ class SpecificationVisitor(HasTraits):
         return node
 
 
-    # def visit_str(self, node):
-    #     return parser.transform(parser.expansion, self.handlers, node)
+    def visit_str(self, node):
+        return Parser.transform('expansion', self.handlers, node)
 
 
 ##################################################

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -1,0 +1,190 @@
+
+import random
+
+import traits.api as T
+from traits.api import HasTraits
+
+import yaml
+from easydict import EasyDict
+
+
+class Provider(HasTraits):
+
+    uuid = T.UUID()
+    name = T.String()
+
+
+class Service(HasTraits):
+
+    uuid = T.UUID()
+    name = T.String()
+    machines = T.Set()
+    parents = T.Set()
+
+    def __str__(self):
+        return '<{} service>'.format(self.name)
+
+    def add_machine(self, machine):
+        self.machines.add(machine)
+        machine.services.add(self)
+
+
+# internal use only
+class _ServiceGroup(HasTraits):
+
+    uuid = T.UUID()
+    services = T.Dict(T.String, Service)
+
+    def __getitem__(self, name):
+        return self.services[name]
+
+    def __setitem__(self, k, v):
+        self.services[k] = v
+
+
+class Machine(HasTraits):
+
+    uuid = T.UUID()
+    name = T.String()
+    services = T.Set(Service)
+    provider = T.Trait(Provider)
+
+
+    def __str__(self):
+        return '<node {} on {}>'.format(self.name, self.provider)
+
+
+    def add_to(self, service):
+        self.services.add(service)
+        service.machines.add(self)
+
+
+# internal use only
+class _MachineCollection(HasTraits):
+    machines = T.List(Machine)
+
+    def assign(self, number, service):
+
+        if number < len(self):
+            subset = random.sample(self.machines, number)
+
+        elif number == len(self):
+            subset = self.machines
+
+        else:
+            msg = ('Cannot allocate more machines ({}) '
+                   'than are in the group ({}).')\
+                  .format(number, len(self.machines))
+            raise ValueError(msg)
+
+        for m in subset:
+            m.add_to(service)
+
+
+    def append(self, item):
+        self.machines.append(item)
+
+
+    def __len__(self):
+        return len(self.machines)
+
+
+
+##################################################
+
+class AnsibleVars(HasTraits):
+
+    kind = T.Trait(None, 'host_vars', 'group_vars')
+    vars = T.Dict()
+
+
+##################################################
+
+class Cluster(HasTraits):
+
+    uuid = T.UUID()
+    provider = T.Trait(Provider)
+    machines = T.Dict(T.String(), T.Trait(Machine))  # name -> Machine
+    services = T.Dict(T.String(), T.Trait(Service))  # name -> Service
+    vars = T.List(T.Trait(AnsibleVars))
+
+
+    @classmethod
+    def load_yaml(cls, path):
+
+        with open(path) as fd:
+            d = yaml.load(fd)
+            d = EasyDict(d)
+
+        services = _load_services(d.services)
+        machines = _load_machines(d.machines, services)
+        hostvars = _load_host_vars(d.host_vars)
+
+        cluster  = cls(
+            machines = dict([(m.name, m) for m in machines]),
+            services = services,
+            vars = [hostvars],
+        )
+
+        return cluster
+
+##################################################
+
+
+def _load_services(root):
+    group = _ServiceGroup()
+
+    for service_name in root:
+        group[service_name] = Service(name=service_name)
+
+    for service_name in root:
+        service = group[service_name]
+        if root[service_name]:
+            parents = root[service_name]
+            assert isinstance(parents, list)
+            for parent_name in parents:
+                parent = group[parent_name]
+                service.parents.add(parent)
+
+    return group.services
+
+
+
+def _load_machines(root, services):
+
+    machines = list()
+
+
+    for machine_name in root:
+        collection = _MachineCollection()
+
+        ### count
+        count = root[machine_name].get('count', 1)
+        for i in xrange(count):
+            collection.append(Machine(name='{}{:02d}'.format(machine_name,i)))
+
+        ### assignments
+        assignments = root[machine_name].get('for', [])
+        for service_name in assignments:
+            service = services[service_name]
+
+            node = assignments[service_name]
+            howmany_default = len(collection)
+            if node:
+                how_many = node.get('assign', howmany_default)
+            else:
+                how_many = howmany_default
+
+            collection.assign(how_many, service)
+
+        machines.extend(collection.machines)
+    return machines
+
+
+def _load_host_vars(root):
+    return AnsibleVars(kind='host_vars', vars=root)
+
+
+def test(path):
+    c = Cluster.load_yaml(path)
+    return c

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -1,6 +1,9 @@
 
 import parser
 from parser import Parser
+import logger as logging
+
+logger = logging.getLogger(__name__)
 
 import random
 import copy
@@ -209,6 +212,7 @@ class ClusterLoader(object):
         
         transformed = visitor.transform(spec_dict)
         new_yaml_str = yaml.dump(transformed, default_flow_style=False)
+        logger.debug('New YAML:\n%s', new_yaml_str)
         return cls.phase1(new_yaml_str)
 
 
@@ -333,8 +337,10 @@ class SpecificationVisitor(HasTraits):
 
 
         for k in node:
-            print 'Visiting', k
+            logger.debug(k)
+            logger.add()
             node[k] = self.visit(node[k])
+            logger.sub()
 
         return node
 
@@ -412,4 +418,5 @@ def test(path):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
     test('cluster.yaml')

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -207,14 +207,14 @@ class SpecificationVisitor(HasTraits):
 
 
     def visit_dict(self, node):
-        inherit = '<inherit>'
+        inherit = '<<inherit>>'
         if inherit in node:
             name = node[inherit]
             path = name.split('.')
             new  = self.spec
             for key in path:
                 new = new[key]
-            del node['<inherit>']
+            del node['<<inherit>>']
             for k,v in node.iteritems():
                 new[k] = v
             node = new

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -149,7 +149,7 @@ class ClusterLoader(object):
     @classmethod
     def phase1(cls, yaml_string):
 
-        d = yaml.load(yaml_string)
+        d = yaml.safe_load(yaml_string)
         d = EasyDict(d)
 
         services = _load_services(d.services)
@@ -168,7 +168,7 @@ class ClusterLoader(object):
     @classmethod
     def phase2(cls, yaml_string, cluster):
 
-        spec_dict = yaml.load(yaml_string)
+        spec_dict = yaml.safe_load(yaml_string)
 
         visitor = SpecificationVisitor(
             handlers = [parser.env_handler],

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -130,18 +130,9 @@ class Cluster(HasTraits):
     services = T.Trait(ServiceGroup)
     vars = T.List(T.Trait(AnsibleVars))
 
-    # @classmethod
-    # def load_yaml(cls, yaml_string, expand=True):
-
-
-        # visitor = parser.Visitor(
-        #     handlers = [parser.env_handler,
-        #                 parser.index_handler],
-        #     context  = cluster,
-        # )
-        # d2 = visit(d)
-
-        # return cluster
+    @classmethod
+    def load_yaml(cls, yaml_string):
+        return ClusterLoader.load_yaml(yaml_string)
 
 
 class ClusterLoader(object):
@@ -375,5 +366,9 @@ def _load_host_vars(root):
 
 
 def test(path):
-    c = ClusterLoader.load_yaml(open(path).read())
+    c = Cluster.load_yaml(open(path).read())
     return c
+
+
+if __name__ == '__main__':
+    test('cluster.yaml')

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -321,7 +321,7 @@ def _load_services(root):
 
 
 
-def _load_machines(root, services):
+def _load_machines(root, services, defaults):
     logger.info('Loading machine definitions').add()
 
     machines = list()
@@ -353,6 +353,20 @@ def _load_machines(root, services):
                 how_many = howmany_default
 
             collection.assign(how_many, service)
+
+        # auth
+        logger.debug('Setting auth for collection %s', machine_name)
+        public_key  = root[machine_name].get('public_key', defaults.auth.public_key)
+        private_key = root[machine_name].get('private_key', defaults.auth.private_key)
+        auth = Auth(public_key=public_key, private_key=private_key)
+        collection.set_auth(auth)
+
+
+        # cloud
+        logger.debug('Setting cloud for collection %s', machine_name)
+        cloudname = root[machine_name].get('cloud', defaults.cloud)
+        collection.set_cloud(cloudname, defaults.provider)
+
 
         logger.sub()
 

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -261,9 +261,9 @@ class ClusterLoader(object):
         d = EasyDict(d)
 
         provider = Provider(parameters=d.defaults.provider)
-        cloud = Cloud(parameters=d.defaults.cloud)
+        cloud = _load_cloud(d.defaults)
         services = _load_services(d.services)
-        machines = _load_machines(d.machines, services)
+        machines = _load_machines(d.machines, services, d.defaults)
         hostvars = _load_host_vars(d.host_vars)
 
         cluster  = Cluster(

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -6,6 +6,7 @@ import camel
 
 import random
 import os
+import json
 
 import pxul.os
 
@@ -236,6 +237,18 @@ class Cluster(HasTraits):
 
 
     def get_inventory_dict(self):
+    def get_inventory_json(self):
+        """Generates the inventory as json
+
+        See Cluster.get_inventory_dict
+
+        :returns: the inventory
+        :rtype: str
+        """
+        d = self.get_inventory_dict()
+        return json.dumps(d, sort_keys=True, indent=2, separators=(',', ': '))
+
+
         """Generates the inventory as a nested dictionary
 
         The generated inventory adheres to the convention for dynamic

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -323,6 +323,7 @@ class ClusterLoader(object):
     def load_yaml(cls, yaml_string):
         cluster = cls.phase1(yaml_string)
         cluster = cls.phase2(yaml_string, cluster)
+        cluster = cls.phase3(cluster)
         return cluster
 
 

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -176,7 +176,7 @@ class ClusterLoader(object):
         )
         
         transformed = visitor.transform(spec_dict)
-        new_yaml_str = yaml.dump(transformed)
+        new_yaml_str = yaml.dump(transformed, default_flow_style=False)
         return cls.phase1(new_yaml_str)
 
 

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -116,7 +116,6 @@ class Machine(HasTraits):
     uuid = T.String()
     name = T.String()
     services = T.Set(Service)
-    provider = T.Trait(Provider)
     cloud = T.Trait(Cloud)
     auth = T.Trait(Auth)
     address = AddressT()

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -237,7 +237,6 @@ class Cluster(HasTraits):
             m.cloud = self.cloud
 
 
-    def get_inventory_dict(self):
     def get_inventory_json(self):
         """Generates the inventory as json
 

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -113,7 +113,7 @@ class Auth(HasTraits):
 
 class Machine(HasTraits):
 
-    uuid = T.UUID()
+    uuid = T.String()
     name = T.String()
     services = T.Set(Service)
     provider = T.Trait(Provider)

--- a/vcl/spec2.py
+++ b/vcl/spec2.py
@@ -158,6 +158,22 @@ class _MachineCollection(HasTraits):
         logger.sub()
 
 
+    def set_auth(self, auth):
+        for m in self.machines:
+            logger.debug('Setting auth for %s to %s', m, auth)
+            m.auth = auth
+
+
+    def set_cloud(self, cloudname, providers):
+
+        if cloudname:
+            for m in self.machines:
+                logger.debug('Setting cloud=%s for %s', cloudname, m)
+                self.cloud = Cloud(name=cloudname,
+                                   parameters=providers[cloudname])
+        else:
+            logger.warning('No cloud defined')
+
     def append(self, item):
         self.machines.append(item)
 

--- a/vcl/state.py
+++ b/vcl/state.py
@@ -7,6 +7,8 @@
 import logger as logging
 logger = logging.getLogger(__name__)
 
+import os.path
+
 import traits.api as T
 from traits.api import HasTraits
 
@@ -19,9 +21,13 @@ class State(HasTraits):
     state = T.DictStrAny()
 
     def _read(self):
-        logger.debug('Reading state from %s', self.storage)
-        with open(self.storage) as fd:
-            return yaml.safe_load(fd)
+        if os.path.exists(self.storage):
+            logger.debug('Reading state from %s', self.storage)
+            with open(self.storage) as fd:
+                return yaml.safe_load(fd)
+        else:
+            logger.debug('Creating in-memory state object')
+            return dict()
 
 
     def _write(self):

--- a/vcl/state.py
+++ b/vcl/state.py
@@ -1,0 +1,49 @@
+#
+# This module provides an api for tracking the state of the virtual
+# cluster.  This allows for recovery if the booting process fails.
+#
+
+
+import logger as logging
+logger = logging.getLogger(__name__)
+
+import traits.api as T
+from traits.api import HasTraits
+
+import yaml
+
+
+class State(HasTraits):
+
+    storage = T.File()
+    state = T.DictStrAny()
+
+    def _read(self):
+        logger.debug('Reading state from %s', self.storage)
+        with open(self.storage) as fd:
+            return yaml.safe_load(fd)
+
+
+    def _write(self):
+        logger.debug('Writing state to %s', self.storage)
+        string = yaml.dump(self.state, default_flow_style=False)
+        with open(self.storage, 'w') as fd:
+            fd.write(string)
+
+
+    def _set(self, namespace, item):
+        logger.debug('Saving state for %s', item)
+        assert item.uuid is not None
+
+        self._read()
+
+        if item.uuid in self.state:
+            logger.warn('%s already stored, overwriting', item)
+
+        self.state[namespace] = item
+
+        self._write()
+
+
+    def set_machine(self, machine):
+        self._set('machines', machine)


### PR DESCRIPTION
This changes the specification file from interpreted python to an extended yaml.
The yaml definition is an extension of the YAML specification to allow for dynamic generation of certain properties, such as host-specific variables indexed by the group the host is in and other features:
- dynamic generation of variables based on group membership
- generation of variables applied identically to all elements of a group
- "inheritance" of other sections of document
- expansion of environment variables

An example of a cluster specification:

``` yaml


defaults:
  auth:
    public_key: ~/.ssh/id_rsa.pub
    private_key: ~/.ssh/id_rsa
  provider:
    openstack:
      prefix: <<env:USER>>-
      flavor: m1.small
      key_name: <<env:HOSTNAME>>
      network: <<env:OS_PROJECT_NAME>>-net
      create_floating_ip: false
      floating_ip_pool: ext-net
      security_groups: ["default"]
      available_security_groups:
        default:
          - port: 22
            accept: 0.0.0.0/0
            protocol: tcp
          - protocol: icmp
        web:
          - port: 80,443,8080
            accept: 0.0.0.0/0
            protocol: tcp
      poll_until_active_seconds: 1
      timeout_until_active_seconds: 360
    futuresystems:
      <<inherit:defaults.provider.openstack>>:
      image: Ubuntu-14.04-64
    chameleon:
      <<inherit:defaults.provider.openstack>>:
      image: CC-Ubuntu14.04
      create_floating_ip: true
  cloud: # chameleon



services:
  zookeeper:
  namenode:
    - hadoop
  journalnode:
    - hadoop
  historyserver:
    - hadoop
  resourcemanager:
    - hadoop
  datanode:
    - hadoop
  hadoop:
  frontend:
  gluster:
  loadbalancer:



machines:
  controller:
    count: 3
    services:
      zookeeper:
      namenode:
        assign: 2
      journalnode:
        assign: 1
      historyserver: 
        assign: 1
      resourcemanager: 
        assign: 2
      datanode:
      frontend: 
        assign: 1
      hadoop:
  datanode:
    count: 2
    services:
      datanode:
    providers:
      chameleon:
        image: m1.xlarge


host_vars:
  <<index:services.zookeeper.machines:name:1>>:
    zookeeper_id:
  <<forall:machines:name>>:
    this_var_a: is the same for all machines
  <<forall:services.hadoop.machines:name>>:
    this_var_b: is defined (and identical) only the "hadoop" nodes
  <<forall:services.zookeeper.machines:name>>:
    this_var_c: is defined only on zookeeper nodes
```
